### PR TITLE
change arguments order

### DIFF
--- a/dataset/dataset.py
+++ b/dataset/dataset.py
@@ -229,7 +229,7 @@ def generate_tokenizer(equations, output, vocab_size):
     tokenizer = Tokenizer(BPE())
     tokenizer.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
     trainer = BpeTrainer(special_tokens=["[PAD]", "[BOS]", "[EOS]"], vocab_size=vocab_size, show_progress=True)
-    tokenizer.train(trainer, [equations])
+    tokenizer.train([equations], trainer)
     tokenizer.save(path=output, pretty=False)
 
 


### PR DESCRIPTION
```
python dataset/dataset.py --equations data/math-vt.txt --out token.txt
```

Command above returns `TypeError` below.

```
TypeError: Can't convert <tokenizers.trainers.BpeTrainer object at 0x------------> to Sequence
```

Method `Tokenizer.train` takes _file list_ as the first argument in `tokenizers==0.10.3` .