### PR TITLE
import problem

### DIFF
--- a/pix2tex/dataset/arxiv.py
+++ b/pix2tex/dataset/arxiv.py
@@ -16,9 +16,10 @@ import chardet
 import logging
 import requests
 import urllib.request
+from tqdm import tqdm
 from urllib.error import HTTPError
-from pix2tex.dataset.extract_latex import *
-from pix2tex.dataset.scraping import *
+from pix2tex.dataset.extract_latex import find_math
+from pix2tex.dataset.scraping import recursive_search
 from pix2tex.dataset.demacro import *
 
 # logging.getLogger().setLevel(logging.INFO)

--- a/pix2tex/dataset/scraping.py
+++ b/pix2tex/dataset/scraping.py
@@ -5,9 +5,7 @@ from tqdm import tqdm
 import html
 import requests
 import re
-import tempfile
-from pix2tex.dataset.arxiv import *
-from pix2tex.dataset.extract_latex import *
+from pix2tex.dataset.extract_latex import find_math
 
 wikilinks = re.compile(r'href="/wiki/(.*?)"')
 htmltags = re.compile(r'<(noscript|script)>.*?<\/\1>', re.S)


### PR DESCRIPTION
1. I noticed `scraping.py` and `arxiv.py` import each other.
2. I noticed `tqdm` is used in `arxiv.py` but not imported. I think it working normally due to 1, because `tqdm` import by `scraping.py`.
3. I adjust `*` to a concrete function that makes me easy to understand the call logical.