### PR TITLE
preprocessing file missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+# lib/
 lib64/
 parts/
 sdist/

--- a/pix2tex/dataset/preprocessing/third_party/match-at/lib/matchAt.js
+++ b/pix2tex/dataset/preprocessing/third_party/match-at/lib/matchAt.js
@@ -1,0 +1,42 @@
+/** @flow */
+
+"use strict";
+
+function getRelocatable(re) {
+  // In the future, this could use a WeakMap instead of an expando.
+  if (!re.__matchAtRelocatable) {
+    // Disjunctions are the lowest-precedence operator, so we can make any
+    // pattern match the empty string by appending `|()` to it:
+    // https://people.mozilla.org/~jorendorff/es6-draft.html#sec-patterns
+    var source = re.source + "|()";
+
+    // We always make the new regex global.
+    var flags = "g" + (re.ignoreCase ? "i" : "") + (re.multiline ? "m" : "") + (re.unicode ? "u" : "")
+    // sticky (/.../y) doesn't make sense in conjunction with our relocation
+    // logic, so we ignore it here.
+    ;
+
+    re.__matchAtRelocatable = new RegExp(source, flags);
+  }
+  return re.__matchAtRelocatable;
+}
+
+function matchAt(re, str, pos) {
+  if (re.global || re.sticky) {
+    throw new Error("matchAt(...): Only non-global regexes are supported");
+  }
+  var reloc = getRelocatable(re);
+  reloc.lastIndex = pos;
+  var match = reloc.exec(str);
+  // Last capturing group is our sentinel that indicates whether the regex
+  // matched at the given location.
+  if (match[match.length - 1] == null) {
+    // Original regex matched.
+    match.length = match.length - 1;
+    return match;
+  } else {
+    return null;
+  }
+}
+
+module.exports = matchAt;


### PR DESCRIPTION
this repo missing a file which could cause the below error

```shell
Error: Cannot find module './LaTeX-OCR/pix2tex/dataset/preprocessing/third_party/match-at/lib/matchAt.js'. Please verify that the package.json has a valid "main" entry
```

copy from [im2markup](https://github.com/harvardnlp/im2markup/tree/master/third_party/match-at)

and I am not sure whether you encountered this [issue](https://github.com/harvardnlp/im2markup/issues/41#issue-686159200) or not?
```shell
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe7 in position 2270: invalid continuation byte
```
if you encountered it, I think it would be better to add a prompt that uses python2.7 on readme.

