### PR TITLE
add shell completions

### DIFF
--- a/pix2tex/__main__.py
+++ b/pix2tex/__main__.py
@@ -1,11 +1,44 @@
 #!/usr/bin/env python
+# https://github.com/iterative/shtab/blob/5358dda86e8ea98bf801a43a24ad73cd9f820c63/examples/customcomplete.py#L11-L22
+YAML_FILE = {
+    "bash": "_shtab_greeter_compgen_yaml_file",
+    "zsh": "_files -g '*.yaml'",
+    "tcsh": "f:*.yaml",
+}
+PTH_FILE = {
+    "bash": "_shtab_greeter_compgen_pth_file",
+    "zsh": "_files -g '*.pth'",
+    "tcsh": "f:*.pth",
+}
+PREAMBLE = {
+    "bash": """\
+# $1=COMP_WORDS[1]
+_shtab_greeter_compgen_yaml_file() {
+  compgen -d -- $1  # recurse into subdirs
+  compgen -f -X '!*?.yaml' -- $1
+}
+
+_shtab_greeter_compgen_pth_file() {
+  compgen -d -- $1  # recurse into subdirs
+  compgen -f -X '!*?.pth' -- $1
+}
+""",
+}
+
+
 def main():
     from argparse import ArgumentParser
+    try:
+        import shtab
+    except ImportError:
+        from . import _shtab as shtab
 
-    parser = ArgumentParser()
+    parser = ArgumentParser('pix2tex')
+    shtab.add_argument_to(parser, preamble=PREAMBLE)
+
     parser.add_argument('-t', '--temperature', type=float, default=.333, help='Softmax sampling frequency')
-    parser.add_argument('-c', '--config', type=str, default='settings/config.yaml', help='path to config file')
-    parser.add_argument('-m', '--checkpoint', type=str, default='checkpoints/weights.pth', help='path to weights file')
+    parser.add_argument('-c', '--config', type=str, default='settings/config.yaml', help='path to config file').complete = YAML_FILE
+    parser.add_argument('-m', '--checkpoint', type=str, default='checkpoints/weights.pth', help='path to weights file').complete = PTH_FILE
     parser.add_argument('--no-cuda', action='store_true', help='Compute on CPU')
     parser.add_argument('--no-resize', action='store_true', help='Resize the image beforehand')
 
@@ -14,7 +47,7 @@ def main():
 
     parser.add_argument('--gui', action='store_true', help='Use GUI (gui only)')
 
-    parser.add_argument('file', nargs='*', type=str, default=None, help='Predict LaTeX code from image file instead of clipboard (cli only)')
+    parser.add_argument('file', nargs='*', type=str, default=None, help='Predict LaTeX code from image file instead of clipboard (cli only)').complete = shtab.FILE
     arguments = parser.parse_args()
 
     import os

--- a/pix2tex/_shtab.py
+++ b/pix2tex/_shtab.py
@@ -1,0 +1,8 @@
+FILE = None
+DIRECTORY = DIR = None
+
+
+def add_argument_to(parser, *args, **kwargs):
+    from argparse import Action
+    Action.complete = None
+    return parser

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ api = [
     'streamlit>=1.8.1',
     'fastapi>=0.75.2',
     'uvicorn[standard]',
-    'python-multipart'
+    'python-multipart',
 ]
 train = [
     'python-Levenshtein>=0.12.2',
@@ -25,6 +25,7 @@ train = [
     'imagesize>=1.2.0',
 ]
 highlight = ['pygments']
+completion = ['shtab']
 
 setuptools.setup(
     name='pix2tex',
@@ -67,11 +68,12 @@ setuptools.setup(
         'albumentations>=0.5.2',
     ],
     extras_require={
-        'all': gui+api+train+highlight,
+        'all': gui + api + train + highlight + completion,
         'gui': gui,
         'api': api,
         'train': train,
         'highlight': highlight,
+        'completion': completion,
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Fix #174

Generate shell completion scripts:

```shell
pix2tex --print-completion bash | sudo tee /usr/share/bash-completion/completions/pix2tex
pix2tex --print-completion zsh | sudo tee /usr/share/zsh/site-functions/_pix2tex
pix2tex --print-completion tcsh | sudo tee /etc/profile.d/pix2tex.completion.csh
```

Result:

```shell
❯ pix2tex -<TAB>  # it complete options
option
--checkpoint         path to weights file
--config             path to config file
-c                   path to config file
--file               Predict LaTeX code from image file instead of clipboard (cli only)
-f                   Predict LaTeX code from image file instead of clipboard (cli only)
--gnome              Use gnome-screenshot to capture screenshot (gui only)
--gui                Use GUI (gui only)
--help               show this help message and exit
...
❯ pix2tex -f <TAB>  # it complete files
file
docker/            docs/              LICENSE            MANIFEST.in        notebooks/         pix2tex/           pix2tex.egg-info/  README.md          setup.cfg          setup.py
❯ pix2tex -m <TAB>  # it complete directories and `*.pth`
checkpoint
docker/            docs/              notebooks/         pix2tex/           pix2tex.egg-info/
❯ pix2tex -m pix2tex/model/checkpoints/<TAB>
checkpoint
image_resizer.pth  __pycache__/       weights.pth
```

It import an extra requirement. Even if user don't install `shtab`, it still can
work because `_shtab.py`:

```python
    try:
        import shtab
    except ImportError:
        from . import _shtab as shtab
```
