### PR TITLE
add support for readline

### DIFF
--- a/pix2tex/cli.py
+++ b/pix2tex/cli.py
@@ -28,12 +28,14 @@ from PIL import Image
 import os
 import sys
 from typing import Tuple
-import readline
 import atexit
 from contextlib import suppress
 import logging
 import yaml
 import re
+
+with suppress(ImportError):
+    import readline
 
 import numpy as np
 import torch
@@ -218,15 +220,17 @@ def main(arguments):
     path = user_data_dir('pix2tex')
     os.makedirs(path, exist_ok=True)
     history_file = os.path.join(path, 'history.txt')
-    with suppress(OSError):
-        readline.read_history_file(history_file)
-    atexit.register(readline.write_history_file, history_file)
+    with suppress(ImportError):
+        with suppress(OSError):
+            readline.read_history_file(history_file)
+        atexit.register(readline.write_history_file, history_file)
     with in_model_path():
         model = LatexOCR(arguments)
         file = arguments.file
         if arguments.file:
             file2tex(file, model, arguments)
-            readline.add_history(file)
+            with suppress(ImportError):
+                readline.add_history(file)
             exit()
         pat = re.compile(r't=([\.\d]+)')
         while True:

--- a/pix2tex/cli.py
+++ b/pix2tex/cli.py
@@ -26,6 +26,7 @@ import pandas.io.clipboard as clipboard
 from PIL import ImageGrab
 from PIL import Image
 import os
+import sys
 from typing import Tuple
 import readline
 import atexit
@@ -161,7 +162,28 @@ class LatexOCR:
 
 
 def output_prediction(pred, args):
-    print(pred, '\n')
+    TERM = os.getenv('TERM', 'xterm')
+    if not sys.stdout.isatty():
+        TERM = 'dumb'
+    try:
+        from pygments import highlight
+        from pygments.lexers import get_lexer_by_name
+        from pygments.formatters import get_formatter_by_name
+
+        if TERM.split('-')[-1] == '256color':
+            formatter_name = 'terminal256'
+        elif TERM != 'dumb':
+            formatter_name = 'terminal'
+        else:
+            formatter_name = None
+        if formatter_name:
+            formatter = get_formatter_by_name(formatter_name)
+            lexer = get_lexer_by_name('tex')
+            print(highlight(pred, lexer, formatter), end='')
+    except ImportError:
+        TERM = 'dumb'
+    if TERM == 'dumb':
+        print(pred)
     if args.show or args.katex:
         try:
             if args.katex:

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ train = [
     'torchtext>=0.6.0',
     'imagesize>=1.2.0',
 ]
+highlight = ['pygments']
 
 setuptools.setup(
     name='pix2tex',
@@ -66,10 +67,11 @@ setuptools.setup(
         'albumentations>=0.5.2',
     ],
     extras_require={
-        'all': gui+api+train,
+        'all': gui+api+train+highlight,
         'gui': gui,
         'api': api,
-        'train': train
+        'train': train,
+        'highlight': highlight,
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Fix #177

```sh
❯ pix2tex
Predict LaTeX code for image ("?"/"h" for help). ~/D  # press <C-C> to throw a KeyboardInterrupt
Predict LaTeX code for image ("?"/"h" for help). ~/Downloads/a.png
{\Bigg[}S=\int_{x}\left\{{\frac{1}{2}}\sum_{a}\partial^{\mu}\chi_{a}\partial_{\mu}\chi_{a}+V(\rho)\right\},

Predict LaTeX code for image ("?"/"h" for help). %  # press <C-D> to throw an EOFError
❯ pix2tex
Predict LaTeX code for image ("?"/"h" for help). ~/Downloads/a.png  # press <C-P> to get the last input of history
```

And I move the `help` to docstring to make the code more readable.

```python
                elif ins in ['?', 'h', 'help']:
                    print(__doc__)
                    continue
```

And I fix the `~` by `os.path.expanduser()`

BTW, it fix the bug about `EOFError`, because there is not any `try/except` for `EOFError` in the original code.

```sh
❯ pix2tex  # original code, press `<C-D>`
Predict LaTeX code for image ("?"/"h" for help). Traceback (most recent call last):
  File "/home/wzy/.local/bin/pix2tex", line 33, in <module>
    sys.exit(load_entry_point('pix2tex', 'console_scripts', 'pix2tex')())
  File "/home/wzy/Desktop/LaTeX-OCR/pix2tex/__main__.py", line 29, in main
    main(arguments)
  File "/home/wzy/Desktop/LaTeX-OCR/pix2tex/cli.py", line 157, in main
    instructions = input('Predict LaTeX code for image ("?"/"h" for help). ')
EOFError
```