### PR TITLE
use pytorch's default path to store checkpoint

### DIFF
--- a/pix2tex/__main__.py
+++ b/pix2tex/__main__.py
@@ -5,7 +5,7 @@ def main():
     parser = ArgumentParser()
     parser.add_argument('-t', '--temperature', type=float, default=.333, help='Softmax sampling frequency')
     parser.add_argument('-c', '--config', type=str, default='settings/config.yaml', help='path to config file')
-    parser.add_argument('-m', '--checkpoint', type=str, default='checkpoints/weights.pth', help='path to weights file')
+    parser.add_argument('-m', '--checkpoint', type=str, default='', help='path to weights file')
     parser.add_argument('--no-cuda', action='store_true', help='Compute on CPU')
     parser.add_argument('--no-resize', action='store_true', help='Resize the image beforehand')
 

--- a/pix2tex/cli.py
+++ b/pix2tex/cli.py
@@ -79,7 +79,7 @@ class LatexOCR:
         self.args.wandb = False
         self.args.device = 'cuda' if torch.cuda.is_available() and not self.args.no_cuda else 'cpu'
         if not os.path.exists(self.args.checkpoint):
-            download_checkpoints()
+            self.args.checkpoint, _ = download_checkpoints()
         self.model = get_model(self.args)
         self.model.load_state_dict(torch.load(self.args.checkpoint, map_location=self.args.device))
         self.model.eval()

--- a/pix2tex/model/checkpoints/get_latest_checkpoint.py
+++ b/pix2tex/model/checkpoints/get_latest_checkpoint.py
@@ -1,7 +1,5 @@
 import requests
 import os
-import tqdm
-import io
 
 from torch.hub import download_url_to_file, get_dir
 
@@ -17,14 +15,14 @@ def get_latest_tag():
 
 
 def download_checkpoints():
-    pix2tex_dir = os.path.join(get_dir(), 'pix2tex')
-    os.makedirs(pix2tex_dir, exist_ok=True)
+    checkpoints_dir = os.path.join(get_dir(), 'checkpoints')
+    os.makedirs(checkpoints_dir, exist_ok=True)
     tag = 'v0.0.1'  # get_latest_tag()
     weights = 'https://github.com/lukas-blecher/LaTeX-OCR/releases/download/%s/weights.pth' % tag
     resizer = 'https://github.com/lukas-blecher/LaTeX-OCR/releases/download/%s/image_resizer.pth' % tag
     cached_files = []
     for url in [weights, resizer]:
-        cached_file = os.path.join(pix2tex_dir, os.path.split(url)[-1])
+        cached_file = os.path.join(checkpoints_dir, os.path.split(url)[-1])
         if not os.path.exists(cached_file):
             download_url_to_file(url, cached_file)
         cached_files += [cached_file]

--- a/pix2tex/model/checkpoints/get_latest_checkpoint.py
+++ b/pix2tex/model/checkpoints/get_latest_checkpoint.py
@@ -3,6 +3,8 @@ import os
 import tqdm
 import io
 
+from torch.hub import download_url_to_file, get_dir
+
 url = 'https://github.com/lukas-blecher/LaTeX-OCR/releases/latest'
 
 
@@ -14,36 +16,19 @@ def get_latest_tag():
     return tag
 
 
-def download_as_bytes_with_progress(url: str, name: str = None) -> bytes:
-    # source: https://stackoverflow.com/questions/71459213/requests-tqdm-to-a-variable
-    resp = requests.get(url, stream=True, allow_redirects=True)
-    total = int(resp.headers.get('content-length', 0))
-    bio = io.BytesIO()
-    if name is None:
-        name = url
-    with tqdm.tqdm(
-        desc=name,
-        total=total,
-        unit='b',
-        unit_scale=True,
-        unit_divisor=1024,
-    ) as bar:
-        for chunk in resp.iter_content(chunk_size=65536):
-            bar.update(len(chunk))
-            bio.write(chunk)
-    return bio.getvalue()
-
-
 def download_checkpoints():
+    pix2tex_dir = os.path.join(get_dir(), 'pix2tex')
+    os.makedirs(pix2tex_dir, exist_ok=True)
     tag = 'v0.0.1'  # get_latest_tag()
-    path = os.path.dirname(__file__)
-    print('download weights', tag, 'to path', path)
     weights = 'https://github.com/lukas-blecher/LaTeX-OCR/releases/download/%s/weights.pth' % tag
     resizer = 'https://github.com/lukas-blecher/LaTeX-OCR/releases/download/%s/image_resizer.pth' % tag
-    for url, name in zip([weights, resizer], ['weights.pth', 'image_resizer.pth']):
-        file = download_as_bytes_with_progress(url, name)
-        open(os.path.join(path, name), "wb").write(file)
-
+    cached_files = []
+    for url in [weights, resizer]:
+        cached_file = os.path.join(pix2tex_dir, os.path.split(url)[-1])
+        if not os.path.exists(cached_file):
+            download_url_to_file(url, cached_file)
+        cached_files += [cached_file]
+    return cached_files
 
 if __name__ == '__main__':
     download_checkpoints()


### PR DESCRIPTION
Fix #178

```sh
❯ pix2tex
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 97.4M/97.4M [00:36<00:00, 2.77MB/s]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 18.5M/18.5M [00:05<00:00, 3.39MB/s]
Predict LaTeX code for image ("?"/"h" for help). /home/wzy/Downloads/a.png
{\Bigg\vert}S=\int_{x}{\Bigg\vert}{\frac{1}{2}}\sum_{a}\partial^{\mu}\chi_{a}\partial_{\mu}\chi_{a}+V(\rho){\Bigg\vert},

Predict LaTeX code for image ("?"/"h" for help). x
❯ tree -L2 ~/.cache/torch/hub/
 /home/wzy/.cache/torch/hub
├──  checkpoints
│  ├──  alexnet-owt-7be5be79.pth
│  ├── ...
│  └──  resnet101-63fe2227.pth
├──  pix2tex
│  ├──  image_resizer.pth
│  └──  weights.pth
└──  pytorch_vision_main
   ├──  __pycache__
   ├── ...
   └──  version.txt
```
