### PR TITLE
Use gnome-screenshot automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There are three ways to get a prediction from an image.
 
 2. Thanks to [@katie-lim](https://github.com/katie-lim), you can use a nice user interface as a quick way to get the model prediction. Just call the GUI with `latexocr`. From here you can take a screenshot and the predicted latex code is rendered using [MathJax](https://www.mathjax.org/) and copied to your clipboard.
 
-    Under linux, it is possible to use the GUI with `gnome-screenshot` which comes with multiple monitor support. You just need to run `latexocr --gnome` (**Note:** you should install `gnome-screenshot` beforehand).
+    Under linux, it is possible to use the GUI with `gnome-screenshot` which comes with multiple monitor support if `gnome-screenshot` was installed beforehand.
 
     ![demo](https://user-images.githubusercontent.com/55287601/117812740-77b7b780-b262-11eb-81f6-fc19766ae2ae.gif)
 

--- a/pix2tex/__main__.py
+++ b/pix2tex/__main__.py
@@ -14,7 +14,6 @@ def main():
     parser.add_argument('-k', '--katex', action='store_true', help='Render the latex code in the browser (cli only)')
 
     parser.add_argument('--gui', action='store_true', help='Use GUI (gui only)')
-    parser.add_argument('--gnome', action='store_true', help='Use gnome-screenshot to capture screenshot (gui only)')
 
     arguments = parser.parse_args()
 

--- a/pix2tex/gui.py
+++ b/pix2tex/gui.py
@@ -1,3 +1,4 @@
+from shutil import which
 import sys
 import os
 import tempfile
@@ -105,7 +106,7 @@ class App(QMainWindow):
     @pyqtSlot()
     def onClick(self):
         self.close()
-        if self.args.gnome:
+        if which('gnome-screenshot'):
             self.snip_using_gnome_screenshot()
         else:
             self.snipWidget.snip()


### PR DESCRIPTION
I notice gnome-screenshot support multi monitor. Why not use it automatically
when it is available? It will be more convenient. Thanks.
