### PR TITLE
Make gui better and fix bug of QWebEngine doesn't display eq on linux

### DIFF
--- a/pix2tex/gui.py
+++ b/pix2tex/gui.py
@@ -2,11 +2,11 @@ import sys
 import os
 import tempfile
 from PyQt5 import QtCore, QtGui
-from PyQt5.QtCore import QObject, Qt, pyqtSlot, pyqtSignal, QThread
+from PyQt5.QtCore import Qt, pyqtSlot, pyqtSignal, QThread
 from PyQt5.QtWebEngineWidgets import QWebEngineView
 from PyQt5.QtGui import QKeySequence
 from PyQt5.QtWidgets import QMainWindow, QApplication, QMessageBox, QVBoxLayout, QWidget, QShortcut,\
-    QPushButton, QTextEdit, QLineEdit, QFormLayout, QHBoxLayout, QCheckBox, QSpinBox, QDoubleSpinBox
+    QPushButton, QTextEdit, QFormLayout, QHBoxLayout, QDoubleSpinBox
 from pix2tex.resources import resources
 from pynput.mouse import Controller
 
@@ -100,7 +100,6 @@ class App(QMainWindow):
         self.snipButton.setText(text)
         self.snipButton.clicked.disconnect()
         self.snipButton.clicked.connect(func)
-        self.displayPrediction()
 
     @pyqtSlot()
     def onClick(self):
@@ -299,6 +298,8 @@ class SnipWidget(QMainWindow):
 
 def main(arguments):
     with in_model_path():
+        if os.name != 'nt':
+            os.environ['QTWEBENGINE_DISABLE_SANDBOX'] = '1'
         app = QApplication(sys.argv)
         ex = App(arguments)
-        sys.exit(app.exec_())
+        sys.exit(app.exec())

--- a/pix2tex/gui.py
+++ b/pix2tex/gui.py
@@ -101,6 +101,7 @@ class App(QMainWindow):
         self.snipButton.setText(text)
         self.snipButton.clicked.disconnect()
         self.snipButton.clicked.connect(func)
+        self.displayPrediction() 
 
     @pyqtSlot()
     def onClick(self):


### PR DESCRIPTION
1. `app.exec_()` is pyqt4's method, `app.exec()` is pyqt5's method
2. I found that math equation displays well in windows but doesn't display in linux platform as description in #109 , so I add system judgment statements by `os` module to make it work correctly
3. I read `gui.py` and find `displayPrediction` function will be called three times in one snip: 
![1](https://user-images.githubusercontent.com/43681138/191706468-30472526-e487-4a49-9c8a-254199660627.png)
`toggleProcessing` function is responsible for the modification of the button signal, not the display function. So I think that is redundancy and inelegant, it should be decoupled here. 
4. Removed some unused modules
5. The code in both linux( arch ) and windows test passed