### PR TITLE
Make the CLI more Unix-friendly

### DIFF
--- a/pix2tex/__main__.py
+++ b/pix2tex/__main__.py
@@ -20,8 +20,10 @@ def main():
     import os
     import sys
 
+    print(arguments)
+
     name = os.path.split(sys.argv[0])[-1]
-    if arguments.gui or arguments.gnome or name in ['pix2tex_gui', 'latexocr']:
+    if arguments.gui or name in ['pix2tex_gui', 'latexocr']:
         from .gui import main
     else:
         from .cli import main

--- a/pix2tex/__main__.py
+++ b/pix2tex/__main__.py
@@ -20,8 +20,6 @@ def main():
     import os
     import sys
 
-    print(arguments)
-
     name = os.path.split(sys.argv[0])[-1]
     if arguments.gui or name in ['pix2tex_gui', 'latexocr']:
         from .gui import main

--- a/pix2tex/cli.py
+++ b/pix2tex/cli.py
@@ -178,6 +178,7 @@ def output_prediction(pred, args):
 
 
 def main(arguments):
+    file = arguments.file
     path = user_data_dir('pix2tex')
     os.makedirs(path, exist_ok=True)
     history_file = os.path.join(path, 'history.txt')
@@ -189,68 +190,13 @@ def main(arguments):
         atexit.register(readline.write_history_file, history_file)
     with in_model_path():
         model = LatexOCR(arguments)
-        file = None
-        while True:
+        img = None
+        if file:
+            img = Image.open(file)
+        else:
             try:
-                instructions = input('Predict LaTeX code for image ("?"/"h" for help). ')
-            except KeyboardInterrupt:
-                # TODO: make the last line gray
-                print("")
-                continue
-            except EOFError:
-                break
-            possible_file = instructions.strip()
-            ins = possible_file.lower()
-            if ins == 'x':
-                break
-            elif ins in ['?', 'h', 'help']:
-                print('''pix2tex help:
-
-    Usage:
-        On Windows and macOS you can copy the image into memory and just press ENTER to get a prediction.
-        Alternatively you can paste the image file path here and submit.
-
-        You might get a different prediction every time you submit the same image. If the result you got was close you
-        can just predict the same image by pressing ENTER again. If that still does not work you can change the temperature
-        or you have to take another picture with another resolution (e.g. zoom out and take a screenshot with lower resolution). 
-
-        Press "x" to close the program.
-        You can interrupt the model if it takes too long by pressing Ctrl+C.
-
-    Visualization:
-        You can either render the code into a png using XeLaTeX (see README) to get an image file back.
-        This is slow and requires a working installation of XeLaTeX. To activate type 'show' or set the flag --show
-        Alternatively you can render the expression in the browser using katex.org. Type 'katex' or set --katex
-
-    Settings:
-        to toggle one of these settings: 'show', 'katex', 'no_resize' just type it into the console
-        Change the temperature (default=0.333) type: "t=0.XX" to set a new temperature.
-                    ''')
-                continue
-            elif ins in ['show', 'katex', 'no_resize']:
-                setattr(arguments, ins, not getattr(arguments, ins, False))
-                print('set %s to %s' % (ins, getattr(arguments, ins)))
-                continue
-            elif os.path.isfile(os.path.realpath(possible_file)):
-                file = possible_file
-            else:
-                t = re.match(r't=([\.\d]+)', ins)
-                if t is not None:
-                    t = t.groups()[0]
-                    model.args.temperature = float(t)+1e-8
-                    print('new temperature: T=%.3f' % model.args.temperature)
-                    continue
-            try:
-                img = None
-                if file:
-                    img = Image.open(file)
-                else:
-                    try:
-                        img = ImageGrab.grabclipboard()
-                    except:
-                        pass
-                pred = model(img)
-                output_prediction(pred, arguments)
-            except KeyboardInterrupt:
+                img = ImageGrab.grabclipboard()
+            except:
                 pass
-            file = None
+        pred = model(img)
+        output_prediction(pred, arguments)


### PR DESCRIPTION
Thank you for this incredible tool!

I've tried using it for my math study workflow, where I need to transcribe lots of math from textbooks, websites and handwritten notes. A specific workflow I had in mind:
1. Grab a screenshot of a sceen area;
2. Feed the screenshot to LaTeX-OCR;
3. Grab the LaTeX prediction from stdout and pipe it into my clipboard.

Unfortunately, the CLI turned out to be barely usable for me: when calling `pix2tex --file pic.png` the utility shows the interactive TUI instead of processing the file right away, so I came up with two changes to fix this:
1. Remove checks for `arguments.gnome` from main (my python env was complaining about `gnome` being absent from  the arguments namespace);
2. Remove interactive TUI from the CLI

You can see the resulting workflow on this gif:
![Peek 2022-09-22 11-19](https://user-images.githubusercontent.com/22235527/191707404-1e7b1aca-5650-4cb8-bdea-f6d914d8b111.gif)

The bash script I'm using:
```bash
#!/usr/bin/bash

# Create a temporary directory
TEMP_DIR=$(mktemp -d) 

# Grab an area screenshot and save it to temp folder
flameshot gui --path $TEMP_DIR/pic.png

# Feed the screenshot to pix2tex and pipe the prediction to clipboard
pix2tex --file $TEMP_DIR/pic.png | xclip -sel clip

# pix2tex takes a couple seconds to process, notify me when done
notify-send "GrabTeX" "TeX is copied to clipboard"

# Remove the temporary directory
rm -rf $TEMP_DIR
```

I would love to make a contribution that enables this kind of workflow for anybody, but I'm pretty new to Python development. Please let me know if there is anything else I should do in this PR in order for it to get merged.
