### PR TITLE
Solved Retina display issues

### DIFF
--- a/pix2tex/gui.py
+++ b/pix2tex/gui.py
@@ -276,10 +276,10 @@ class SnipWidget(QMainWindow):
         # account for retina display. #TODO how to check if device is actually using retina display
         factor = 2 if sys.platform == "darwin" else 1
 
-        x1 = int(min(startPos[0], endPos[0])*factor)
-        y1 = int(min(startPos[1], endPos[1])*factor)
-        x2 = int(max(startPos[0], endPos[0])*factor)
-        y2 = int(max(startPos[1], endPos[1])*factor)
+        x1 = int(min(startPos[0], endPos[0]))
+        y1 = int(min(startPos[1], endPos[1]))
+        x2 = int(max(startPos[0], endPos[0]))
+        y2 = int(max(startPos[1], endPos[1]))
 
         self.repaint()
         QApplication.processEvents()
@@ -296,6 +296,9 @@ class SnipWidget(QMainWindow):
         self.begin = QtCore.QPoint()
         self.end = QtCore.QPoint()
         self.parent.returnSnip(img)
+        
+        
+        img.show() #this line is used only to check what part of the screen is captured. It can be deleted later
 
 
 def main(arguments):

--- a/pix2tex/gui.py
+++ b/pix2tex/gui.py
@@ -296,10 +296,6 @@ class SnipWidget(QMainWindow):
         self.begin = QtCore.QPoint()
         self.end = QtCore.QPoint()
         self.parent.returnSnip(img)
-        
-        
-        img.show() #this line is used only to check what part of the screen is captured. It can be deleted later
-
 
 def main(arguments):
     with in_model_path():


### PR DESCRIPTION
Initially x1,y1,x2,y2 coordinates in pixel where multiplied by 2 on retina displays but when grabbing you divide by 2 again. This does not solve the issue which is related only to grab where only the box captured must be scaled. Hence the proposed change solve the issue and you can verify with img.show() to check the part of the screen captured