### PR TITLE
Update Snip button on MacOs

### DIFF
--- a/pix2tex/gui.py
+++ b/pix2tex/gui.py
@@ -65,12 +65,8 @@ class App(QMainWindow):
                 self.snipButton = QPushButton('Snip [Alt+S]', self)
                 self.snipButton.clicked.connect(self.onClick)
 
-        if sys.platform == "darwin":
-                self.shortcut = QShortcut(QKeySequence("Alt+S"), self)
-                self.shortcut.activated.connect(self.onClick)
-        else:
-                self.shortcut = QShortcut(QKeySequence("Alt+S"), self)
-                self.shortcut.activated.connect(self.onClick)
+        self.shortcut = QShortcut(QKeySequence("Alt+S"), self)
+        self.shortcut.activated.connect(self.onClick)
 
         # Create retry button
         self.retryButton = QPushButton('Retry', self)

--- a/pix2tex/gui.py
+++ b/pix2tex/gui.py
@@ -58,11 +58,19 @@ class App(QMainWindow):
         self.tempField.setSingleStep(0.1)
 
         # Create snip button
-        self.snipButton = QPushButton('Snip [Alt+S]', self)
-        self.snipButton.clicked.connect(self.onClick)
+        if sys.platform == "darwin":
+                self.snipButton = QPushButton('Snip [Option+S]', self)
+                self.snipButton.clicked.connect(self.onClick) 
+        else:
+                self.snipButton = QPushButton('Snip [Alt+S]', self)
+                self.snipButton.clicked.connect(self.onClick)
 
-        self.shortcut = QShortcut(QKeySequence("Alt+S"), self)
-        self.shortcut.activated.connect(self.onClick)
+        if sys.platform == "darwin":
+                self.shortcut = QShortcut(QKeySequence("Alt+S"), self)
+                self.shortcut.activated.connect(self.onClick)
+        else:
+                self.shortcut = QShortcut(QKeySequence("Alt+S"), self)
+                self.shortcut.activated.connect(self.onClick)
 
         # Create retry button
         self.retryButton = QPushButton('Retry', self)

--- a/pix2tex/gui.py
+++ b/pix2tex/gui.py
@@ -102,7 +102,10 @@ class App(QMainWindow):
             text = 'Interrupt'
             func = self.interrupt
         else:
-            text = 'Snip [Alt+S]'
+            if sys.platform == "darwin":
+                text = 'Snip [Option+S]'
+            else: 
+                text = 'Snip [Alt+S]'
             func = self.onClick
             self.retryButton.setEnabled(True)
         self.shortcut.setEnabled(not self.isProcessing)


### PR DESCRIPTION
On MacOS screenshot shortcut is Option+S, adjusted the text displayed in the button.