### PR TITLE
detect retina screens

### DIFF
--- a/pix2tex/gui.py
+++ b/pix2tex/gui.py
@@ -296,6 +296,7 @@ class SnipWidget(QMainWindow):
                 img = ImageGrab.grab(bbox=(x1//self.args.factor, y1//self.args.factor, x2//self.args.factor, y2//self.args.factor), all_screens=True)
             else:
                 raise e
+        img.show()
         QApplication.processEvents()
 
         self.close()

--- a/pix2tex/gui.py
+++ b/pix2tex/gui.py
@@ -280,13 +280,12 @@ class SnipWidget(QMainWindow):
 
         startPos = self.startPos
         endPos = self.mouse.position
-        # account for retina display. #TODO how to check if device is actually using retina display
-        factor = 2 if sys.platform == "darwin" else 1
+        # account for retina display. 
 
-        x1 = int(min(startPos[0], endPos[0]))
-        y1 = int(min(startPos[1], endPos[1]))
-        x2 = int(max(startPos[0], endPos[0]))
-        y2 = int(max(startPos[1], endPos[1]))
+        x1 = int(min(startPos[0], endPos[0])*self.args.factor)
+        y1 = int(min(startPos[1], endPos[1])*self.args.factor)
+        x2 = int(max(startPos[0], endPos[0])*self.args.factor)
+        y2 = int(max(startPos[1], endPos[1])*self.args.factor)
 
         self.repaint()
         QApplication.processEvents()
@@ -294,7 +293,7 @@ class SnipWidget(QMainWindow):
             img = ImageGrab.grab(bbox=(x1, y1, x2, y2), all_screens=True)
         except Exception as e:
             if sys.platform == "darwin":
-                img = ImageGrab.grab(bbox=(x1//factor, y1//factor, x2//factor, y2//factor), all_screens=True)
+                img = ImageGrab.grab(bbox=(x1//self.args.factor, y1//self.args.factor, x2//self.args.factor, y2//self.args.factor), all_screens=True)
             else:
                 raise e
         QApplication.processEvents()
@@ -309,5 +308,7 @@ def main(arguments):
         if os.name != 'nt':
             os.environ['QTWEBENGINE_DISABLE_SANDBOX'] = '1'
         app = QApplication(sys.argv)
+        screen = app.primaryScreen()
+        arguments.factor = screen.devicePixelRatio()
         ex = App(arguments)
         sys.exit(app.exec())

--- a/pix2tex/gui.py
+++ b/pix2tex/gui.py
@@ -29,7 +29,7 @@ class App(QMainWindow):
         self.args = args
         self.model = cli.LatexOCR(self.args)
         self.initUI()
-        self.snipWidget = SnipWidget(self)
+        self.snipWidget = SnipWidget(self, args.factor)
         self.show()
 
     def initUI(self):
@@ -220,9 +220,10 @@ class ModelThread(QThread):
 class SnipWidget(QMainWindow):
     isSnipping = False
 
-    def __init__(self, parent):
+    def __init__(self, parent, factor=1):
         super().__init__()
         self.parent = parent
+        self.factor = factor
 
         monitos = get_monitors()
         bboxes = np.array([[m.x, m.y, m.width, m.height] for m in monitos])
@@ -282,10 +283,10 @@ class SnipWidget(QMainWindow):
         endPos = self.mouse.position
         # account for retina display. 
 
-        x1 = int(min(startPos[0], endPos[0])*self.args.factor)
-        y1 = int(min(startPos[1], endPos[1])*self.args.factor)
-        x2 = int(max(startPos[0], endPos[0])*self.args.factor)
-        y2 = int(max(startPos[1], endPos[1])*self.args.factor)
+        x1 = int(min(startPos[0], endPos[0])*self.factor)
+        y1 = int(min(startPos[1], endPos[1])*self.factor)
+        x2 = int(max(startPos[0], endPos[0])*self.factor)
+        y2 = int(max(startPos[1], endPos[1])*self.factor)
 
         self.repaint()
         QApplication.processEvents()
@@ -293,7 +294,7 @@ class SnipWidget(QMainWindow):
             img = ImageGrab.grab(bbox=(x1, y1, x2, y2), all_screens=True)
         except Exception as e:
             if sys.platform == "darwin":
-                img = ImageGrab.grab(bbox=(x1//self.args.factor, y1//self.args.factor, x2//self.args.factor, y2//self.args.factor), all_screens=True)
+                img = ImageGrab.grab(bbox=(x1//self.factor, y1//self.factor, x2//self.factor, y2//self.factor), all_screens=True)
             else:
                 raise e
         img.show()


### PR DESCRIPTION
I found `QScreen` has an attribute `devicePixelRatio` that is 2 for retina screens and 1 for non-retina screens.
Here I replaced the hard coded factor from before.

I need somebody to help me with testing because I don't have any devices with macOS.
@FrankFrank9 would you be so kind and give this a go?