### PR TITLE
feat: add utf-8 support for reading README file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 # read the contents of your README file
 from pathlib import Path
 this_directory = Path(__file__).parent
-long_description = (this_directory / 'README.md').read_text()
+long_description = (this_directory / 'README.md').read_text(encoding='utf-8')
 
 gui = [
     'PyQt5',


### PR DESCRIPTION
When I install manually using the following command:

```bash
$ python setup.py install
```

I reported a character encoding problem:

```bash
Traceback (most recent call last):
  File "setup.py", line 8, in <module>
    long_description = (this_directory / 'README.md').read_text()
  File "C:\Users\i\.conda\envs\pytorch\lib\pathlib.py", line 1237, in read_text
    return f.read()
UnicodeDecodeError: 'gbk' codec can't decode byte 0xa4 in position 1033: illegal multibyte sequence
```

So I wanna add encoding support:

```diff
-long_description = (this_directory / 'README.md').read_text()
+long_description = (this_directory / 'README.md').read_text(encoding='utf-8')
```