### PR TITLE
Allow overriding screenshot tool with environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There are three ways to get a prediction from an image.
 
 2. Thanks to [@katie-lim](https://github.com/katie-lim), you can use a nice user interface as a quick way to get the model prediction. Just call the GUI with `latexocr`. From here you can take a screenshot and the predicted latex code is rendered using [MathJax](https://www.mathjax.org/) and copied to your clipboard.
 
-    Under linux, it is possible to use the GUI with `gnome-screenshot` which comes with multiple monitor support if `gnome-screenshot` was installed beforehand.
+    Under linux, it is possible to use the GUI with `gnome-screenshot` (which comes with multiple monitor support) if `gnome-screenshot` was installed beforehand. For Wayland, `grim` and `slurp` will be used when they are both available. Note that `gnome-screenshot` is not compatible with wlroots-based Wayland compositors. Since `gnome-screenshot` will be preferred when available, you may have to set the environment variable `SCREENSHOT_TOOL` to `grim` in this case (other available values are `gnome-screenshot` and `pil`).
 
     ![demo](https://user-images.githubusercontent.com/55287601/117812740-77b7b780-b262-11eb-81f6-fc19766ae2ae.gif)
 

--- a/pix2tex/gui.py
+++ b/pix2tex/gui.py
@@ -111,7 +111,13 @@ class App(QMainWindow):
     @pyqtSlot()
     def onClick(self):
         self.close()
-        if which('gnome-screenshot'):
+        if os.environ.get('SCREENSHOT_TOOL') == "gnome-screenshot":
+            self.snip_using_gnome_screenshot()
+        elif os.environ.get('SCREENSHOT_TOOL') == "grim":
+            self.snip_using_grim()
+        elif os.environ.get('SCREENSHOT_TOOL') == "pil":
+            self.snipWidget.snip()
+        elif which('gnome-screenshot'):
             self.snip_using_gnome_screenshot()
         elif which('grim') and which('slurp'):
             self.snip_using_grim()


### PR DESCRIPTION
This is useful for wlroots compositors on systems which have gnome-screenshot installed. I also added a bit of info to the README.

I did take a look at whether it would be possible to do this automatically. Unfortunately `gnome-screenshot` just fails silently, so I think this is the safest option.