### PR TITLE
Remove printing file path when using as pure cli

### DIFF
--- a/pix2tex/cli.py
+++ b/pix2tex/cli.py
@@ -224,7 +224,8 @@ def main(arguments):
         model = LatexOCR(arguments)
         if files:
             for file in check_file_path(arguments.file, wdir):
-                print(file + ': ', end='')
+                if len(files)>1:
+                    print(file + ': ', end='')
                 predict(model, file, arguments)
                 model.last_pic = None
                 with suppress(NameError):


### PR DESCRIPTION
When using pix2tex as a pure CLI tool, for example in a bash script, printing the file path is unnecessary and makes parsing the output of the tool needlessly difficult. 

If changing the interface like this is not desirable, please let me know and I could work in using a seperate command line argument for this behaviour instead

Ideally this would also work for multiple files, but I see there's some async going on so the order of files in the input is not necessarily the same as the output