### PR TITLE
Add support for screencapture on KDE Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There are three ways to get a prediction from an image.
 
 2. Thanks to [@katie-lim](https://github.com/katie-lim), you can use a nice user interface as a quick way to get the model prediction. Just call the GUI with `latexocr`. From here you can take a screenshot and the predicted latex code is rendered using [MathJax](https://www.mathjax.org/) and copied to your clipboard.
 
-    Under linux, it is possible to use the GUI with `gnome-screenshot` (which comes with multiple monitor support) if `gnome-screenshot` was installed beforehand. For Wayland, `grim` and `slurp` will be used when they are both available. Note that `gnome-screenshot` is not compatible with wlroots-based Wayland compositors. Since `gnome-screenshot` will be preferred when available, you may have to set the environment variable `SCREENSHOT_TOOL` to `grim` in this case (other available values are `gnome-screenshot` and `pil`).
+    Under linux, it is possible to use the GUI with `gnome-screenshot` (which comes with multiple monitor support). For other Wayland compositers, `grim` and `slurp` will be used for wlroots-based Wayland compositers and `spectacle` for KDE Plasma. Note that `gnome-screenshot` is not compatible with wlroots or Qt based compositers. Since `gnome-screenshot` will be preferred when available, you may have to set the environment variable `SCREENSHOT_TOOL` to `grim` or `spectacle` in these cases (other available values are `gnome-screenshot` and `pil`).
 
     ![demo](https://user-images.githubusercontent.com/55287601/117812740-77b7b780-b262-11eb-81f6-fc19766ae2ae.gif)
 

--- a/pix2tex/gui.py
+++ b/pix2tex/gui.py
@@ -113,6 +113,8 @@ class App(QMainWindow):
         self.close()
         if os.environ.get('SCREENSHOT_TOOL') == "gnome-screenshot":
             self.snip_using_gnome_screenshot()
+        elif os.environ.get('SCREENSHOT_TOOL') == "spectacle":
+            self.snip_using_spectacle()
         elif os.environ.get('SCREENSHOT_TOOL') == "grim":
             self.snip_using_grim()
         elif os.environ.get('SCREENSHOT_TOOL') == "pil":
@@ -140,6 +142,16 @@ class App(QMainWindow):
         except:
             print(f"Failed to load saved screenshot! Did you cancel the screenshot?")
             print("If you don't have gnome-screenshot installed, please install it.")
+            self.returnSnip()
+
+    def snip_using_spectacle(self):
+        try:
+            with tempfile.NamedTemporaryFile() as tmp:
+                subprocess.run(["spectacle", "-r", "-b", "-n", "-o", f"{tmp.name}"])
+                self.returnSnip(Image.open(tmp.name))
+        except:
+            print(f"Failed to load saved screenshot! Did you cancel the screenshot?")
+            print("If you don't have spectacle installed, please install it.")
             self.returnSnip()
 
     def snip_using_grim(self):


### PR DESCRIPTION
Since KDE Plasma doesn't use Gnome or wlroot's screen capture protocol, add support for spectacle as an option in  linux wayland.