### PR TITLE
Update streamlit.py with image upload and paste functionality

### DIFF
--- a/pix2tex/api/streamlit.py
+++ b/pix2tex/api/streamlit.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
 
     source = st.radio(
         "Choose the source of the image",
-        options=["Paste", "Upload"],
+        options=["Upload", "Paste"],
     )
 
     image = None

--- a/pix2tex/api/streamlit.py
+++ b/pix2tex/api/streamlit.py
@@ -1,32 +1,60 @@
 import requests
 from PIL import Image
-import streamlit
+import streamlit as st
+from st_img_pastebutton import paste
+from io import BytesIO
+import base64
 
-if __name__ == '__main__':
-    streamlit.set_page_config(page_title='LaTeX-OCR')
-    streamlit.title('LaTeX OCR')
-    streamlit.markdown('Convert images of equations to corresponding LaTeX code.\n\nThis is based on the `pix2tex` module. Check it out [![github](https://img.shields.io/badge/LaTeX--OCR-visit-a?style=social&logo=github)](https://github.com/lukas-blecher/LaTeX-OCR)')
 
-    uploaded_file = streamlit.file_uploader(
-        'Upload an image an equation',
-        type=['png', 'jpg'],
+def encode_image(file):
+    _, encoded = file.split(",", 1)
+    binary_data = base64.b64decode(encoded)
+    bytes_data = BytesIO(binary_data)
+    return bytes_data
+
+
+if __name__ == "__main__":
+    st.set_page_config(page_title="LaTeX-OCR")
+    st.title("LaTeX OCR")
+    st.markdown(
+        "Convert images of equations to corresponding LaTeX code.\n\nThis is based on the `pix2tex` module. Check it out [![github](https://img.shields.io/badge/LaTeX--OCR-visit-a?style=social&logo=github)](https://github.com/lukas-blecher/LaTeX-OCR)"
     )
 
-    if uploaded_file is not None:
-        image = Image.open(uploaded_file)
-        streamlit.image(image)
-    else:
-        streamlit.text('\n')
+    source = st.radio(
+        "Choose the source of the image",
+        options=["Paste", "Upload"],
+    )
 
-    if streamlit.button('Convert'):
-        if uploaded_file is not None and image is not None:
-            with streamlit.spinner('Computing'):
-                response = requests.post('http://127.0.0.1:8502/predict/', files={'file': uploaded_file.getvalue()})
+    image = None
+
+    if source == "Upload":
+        uploaded_file = st.file_uploader(
+            "Upload an image of an equation",
+            type=["png", "jpg"],
+        )
+
+        if uploaded_file is not None:
+            st.image(Image.open(uploaded_file))
+            image = uploaded_file.getvalue()
+
+    if source == "Paste":
+        pasted_file = paste("Paste an image of an equation")
+
+        if pasted_file is not None:
+            image = encode_image(pasted_file)
+            st.image(image)
+
+    if st.button("Convert"):
+        if image is not None:
+            with st.spinner("Computing"):
+                response = requests.post(
+                    "http://127.0.0.1:8502/predict/", files={"file": image}
+                )
             if response.ok:
                 latex_code = response.json()
-                streamlit.code(latex_code, language='latex')
-                streamlit.markdown(f'$\\displaystyle {latex_code}$')
+                st.code(latex_code, language="latex")
+                st.markdown(f"$\\displaystyle {latex_code}$")
             else:
-                streamlit.error(response.text)
+                st.error(response.text)
         else:
-            streamlit.error('Please upload an image.')
+            st.error("No image selected")

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ api = [
     'streamlit>=1.8.1',
     'fastapi>=0.75.2',
     'uvicorn[standard]',
-    'python-multipart'
+    'python-multipart',
+    'st_img_pastebutton>=0.0.3',
 ]
 train = [
     'python-Levenshtein>=0.12.2',


### PR DESCRIPTION
Added a radio component to select between `Paste` and `Upload`, the image pasting functionality is provided by [st-img-pastebutton](https://pypi.org/project/st-img-pastebutton/), which introduces new requirement.

## preview

- selecting  `Paste`
![1716989970424.png](http://117.72.64.190:40027/i/2024/05/29/66573024801af.png)

- selecting `Upload`
![1716989985689.png](http://117.72.64.190:40027/i/2024/05/29/66573024ad718.png)