### PR TITLE
chore: rewrite extract_latex.py to not use numpy

### DIFF
--- a/pix2tex/dataset/extract_latex.py
+++ b/pix2tex/dataset/extract_latex.py
@@ -2,7 +2,6 @@ import argparse
 import html
 import os
 import re
-import numpy as np
 from typing import List
 
 MIN_CHARS = 1
@@ -33,8 +32,8 @@ def check_brackets(s):
                 continue
             else:
                 a.append(-1)
-    b = np.cumsum(a)
-    if len(b) > 1 and b[-1] != 0:
+    b = sum(a)
+    if len(a) > 1 and b != 0:
         raise ValueError(s)
     surrounding = s[-1] == '}' and surrounding
     if not surrounding:


### PR DESCRIPTION
This pull request includes changes to the `pix2tex/dataset/extract_latex.py` file to simplify the code and remove unnecessary dependencies. The most important changes include removing the `numpy` import and refactoring the `check_brackets` function to use built-in Python functions instead of `numpy`.

Codebase simplification:

* [`pix2tex/dataset/extract_latex.py`](diffhunk://#diff-82cc89104ef6ca80e1eb90e5d06485eeab0dbe48caeb6fa2a78b2ff093e75ee4L5): Removed the import of the `numpy` library as it was not necessary for the operations being performed.
* [`pix2tex/dataset/extract_latex.py`](diffhunk://#diff-82cc89104ef6ca80e1eb90e5d06485eeab0dbe48caeb6fa2a78b2ff093e75ee4L36-R36): Refactored the `check_brackets` function to use the built-in `sum` function instead of `numpy.cumsum`, simplifying the code and removing the dependency on `numpy`.

- get rid of unnecessary dependencies
- get the same functionality
- faster code