### PR TITLE
Fix: Fix the fatal error caused by resources.py

### DIFF
--- a/pix2tex/resources/resources.py
+++ b/pix2tex/resources/resources.py
@@ -3,7 +3,7 @@
 # Created by: The Resource Compiler for Qt version 6.4.2
 # WARNING! All changes made in this file will be lost!
 
-from PySide6 import QtCore
+from PyQt6 import QtCore
 
 qt_resource_data = b"\
 \x00\x02*\x89\


### PR DESCRIPTION
When running `latexocr`, it always reports error

![image](https://github.com/user-attachments/assets/f6e38883-c8b8-41cb-8334-9744f82ff007)

And I fixed it, actually just an import mistake. Now works fine.