### PR TITLE
add webui.py to support remote UI usage

### DIFF
--- a/pix2tex/webui.py
+++ b/pix2tex/webui.py
@@ -1,0 +1,33 @@
+import gradio as gr
+from pix2tex.cli import LatexOCR
+from PIL import Image
+
+
+custom_css = """
+footer {
+    display: none !important;
+}
+"""
+
+
+model = LatexOCR()
+
+
+
+def to_tex(image):
+    img=Image.fromarray(image, mode='RGB')
+    return model(img)
+
+with gr.Blocks(css=custom_css) as interface:
+    # 标题
+    gr.Markdown("## Image to Latex")
+    
+    # 垂直排列的组件
+    with gr.Column():
+        input_component = gr.Image(label="Input Image",placeholder="Drag image or click to upload")
+        output_component = gr.Textbox(label="Generated Latex Code")
+    
+    # 添加按钮触发处理
+    btn = gr.Button("Convert")
+    btn.click(fn=to_tex, inputs=input_component, outputs=output_component)
+interface.launch(share=True)

--- a/pix2tex/webui.py
+++ b/pix2tex/webui.py
@@ -19,15 +19,14 @@ def to_tex(image):
     return model(img)
 
 with gr.Blocks(css=custom_css) as interface:
-    # 标题
     gr.Markdown("## Image to Latex")
     
-    # 垂直排列的组件
+    
     with gr.Column():
         input_component = gr.Image(label="Input Image",placeholder="Drag image or click to upload")
         output_component = gr.Textbox(label="Generated Latex Code")
     
-    # 添加按钮触发处理
+    
     btn = gr.Button("Convert")
     btn.click(fn=to_tex, inputs=input_component, outputs=output_component)
-interface.launch(share=True)
+interface.launch(server_name="0.0.0.0")


### PR DESCRIPTION
We only have GPU in remote linux server without remote desktop. So I added a webui based on gradio. Then we can use it in our own laptop.

![456268656-d4c6cdc7-87be-4ade-a7b6-42731be16776](https://github.com/user-attachments/assets/48f6c99d-9bdf-455b-9fb6-1f5818494628)

Now we can open brower in anywhere, and type ip:7860 to use the LatexOCR function。The webpage support i**mage selection, drag and paste from clipboard**.

**require** user to install gradio by: pip install gradio

**usage**: execute "python webui.py" in server and access "ip:7860" in a browser

![image](https://github.com/user-attachments/assets/4fc7da12-bd49-4e5f-8c99-bf8854e2901a)

Besides, since many web browsers (such as chrome) forbidden the remote site access clipboard, so the function "paste from clipboard" may only available in localhost
