### PR TITLE
Fixed installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ The goal of this project is to create a learning based system that takes an imag
 ## Using the model
 To run the model you need Python 3.7+
 
-If you don't have PyTorch installed. Follow their instructions [here](https://pytorch.org/get-started/locally/).
+If you don't have PyTorch installed, follow their instructions [here](https://pytorch.org/get-started/locally/).
+
+Install the Python development package for your distribution (e.g. `dnf install python3-devel`): you will need this for installing the next package!
 
 Install the package `pix2tex`: 
 


### PR DESCRIPTION
While running `pip install "pix2tex[gui]"`, the installation would halt due to this error: `src/evdev/input.c:10:10: fatal error: Python.h: No such file or directory`. A [Google search](https://www.google.com/search?as_q=&as_epq=src%2Fevdev%2Finput.c%3A10%3A10%3A+fatal+error%3A+Python.h%3A+No+such+file+or+directory&as_oq=&as_eq=&as_nlo=&as_nhi=&lr=&cr=&as_qdr=all&as_sitesearch=&as_occt=any&as_filetype=&tbs=) led me to [this issue](https://github.com/pwr-Solaar/Solaar/issues/3087), which seems to describe the same problem, as running `sudo dnf install python3-devel` allowed me to successfully build the `pix2tex[gui]` package.